### PR TITLE
Change target GCDWebserver Pod to a supported version.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
         <source url="https://github.com/CocoaPods/Specs.git"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="GCDWebServer" git="https://github.com/readium/GCDWebServer.git" branch="master"/>
+        <pod name="GCDWebServer" git="https://github.com/readium/GCDWebServer.git" tag="3.7.5"/>
       </pods>
     </podspec>
     

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
         <source url="https://github.com/CocoaPods/Specs.git"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="GCDWebServer" spec="~> 3.5.2"/>
+        <pod name="GCDWebServer" spec="https://github.com/readium/GCDWebServer.git"/>
       </pods>
     </podspec>
     

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,7 @@
         <source url="https://github.com/CocoaPods/Specs.git"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="GCDWebServer" spec="https://github.com/readium/GCDWebServer.git"/>
+        <pod name="GCDWebServer" git="https://github.com/readium/GCDWebServer.git" branch="master"/>
       </pods>
     </podspec>
     


### PR DESCRIPTION
Change the plugin to use a [new fork](https://github.com/readium/GCDWebServer/releases) of the GCDWebserver that is seeing some level of support but also supports iOS 11, as the miniumum target was 8 in the [official](https://github.com/swisspol/GCDWebServer) GCDWebserver (now archived) project.

Docs for change spec: https://cordova.apache.org/docs/en/11.x/plugin_ref/spec.html#pods